### PR TITLE
Update command path in README to use ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add to `.claude/settings.local.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "node .claude/hooks/react-app/quality-check.js"
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/react-app/quality-check.js"
           }
         ]
       }


### PR DESCRIPTION
Use $CLAUDE_PROJECT_DIR in command path per docs - https://docs.anthropic.com/en/docs/claude-code/hooks-guide#markdown-formatting-hook